### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module cryptsetup
+module github.com/martinjungblut/go-cryptsetup
 
 go 1.16


### PR DESCRIPTION
This is unable to import the module with wrong module name in `go.mod`.